### PR TITLE
Added babel as dependency for babel/polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "async": "^1.0.0",
+    "babel": "^5.4.7",
     "bootstrap": "^3.3.4",
     "compression": "^1.0.3",
     "cors": "^2.5.2",


### PR DESCRIPTION
Fixes: Error: Cannot find module 'babel/polyfill' from 'E:\projects\movies-explorer\client\js' on npm install.
